### PR TITLE
Fix for issue glayzzle#27

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -232,9 +232,9 @@ declare module "php-reflection" {
         isFinal: Boolean;
         getExtends(): Class;
         getImplements(): Interface[];
-        getProperties(includeParents?: boolean): Property[];
-        getConstants(includeParents?: boolean): Constant[];
-        getMethods(includeParents?: boolean): Method[];
+        getProperties(includeParents?: boolean): {[name: string]: Property};
+        getConstants(includeParents?: boolean): {[name: string]: Constant};
+        getMethods(includeParents?: boolean): {[name: string]: Method};
     }
 
     export class Trait extends Node {


### PR DESCRIPTION
Corrected return type for `getProperties()`, `getConstants()` and `ge…tMethods()` methods of the `Class` class as actual implementation returned keyed object rather than array.

[Issue #27](https://github.com/glayzzle/php-reflection/issues/27)